### PR TITLE
Call super without argument

### DIFF
--- a/src/kawaz/apps/blogs/models.py
+++ b/src/kawaz/apps/blogs/models.py
@@ -59,12 +59,12 @@ class Entry(models.Model):
                 self.publish_at = None
             elif self.publish_at == None:
                 self.publish_at = datetime.datetime.now()
-        super(Entry, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     def clean(self):
         if self.category and self.author != self.category.author:
             raise ValidationError('Category must be owned by author.')
-        super(Entry, self).clean()
+        super().clean()
 
 from permission.logics import PermissionLogic
 

--- a/src/kawaz/apps/events/models.py
+++ b/src/kawaz/apps/events/models.py
@@ -85,7 +85,7 @@ class Event(models.Model):
                 raise ValidationError(_('The period of event is too long.'))
         elif self.period_end and not self.period_start:
             raise ValidationError(_('You must set end time too'))
-        super(Event, self).clean()
+        super().clean()
 
     def attend(self, user, save=True):
         '''Add user to attendees'''

--- a/src/kawaz/apps/projects/models.py
+++ b/src/kawaz/apps/projects/models.py
@@ -80,7 +80,7 @@ class Project(models.Model):
         if self.pk is None:
             group = Group.objects.get_or_create(name="project_%s" % self.slug)[0]
             self.group = group
-        return super(Project, self).save(*args, **kwargs)
+        return super().save(*args, **kwargs)
 
     def join(self, user, save=True):
         '''Add user to the project'''


### PR DESCRIPTION
Python 3 allow to call `super` without argument.
To prevent human error, `super` should be called in this new way.

https://docs.python.org/3/library/functions.html#super
