### PR TITLE
EventListにCategoryFilter追加した

### DIFF
--- a/src/kawaz/apps/events/filters.py
+++ b/src/kawaz/apps/events/filters.py
@@ -1,0 +1,22 @@
+# ! -*- coding: utf-8 -*-
+#
+# created by giginet on 2014/9/28
+#
+__author__ = 'giginet'
+from django.utils.translation import ugettext as _
+import django_filters
+from django_filters import filters
+from .models import Event
+from .models import Category
+from kawaz.core.filters.widgets import ListGroupLinkWidget
+
+
+class EventFilter(django_filters.FilterSet):
+    category = filters.ModelChoiceFilter(
+        label=_('Categories'),
+        queryset=Category.objects.all(),
+        widget=ListGroupLinkWidget(choices=[('', _('All'))]))
+
+    class Meta:
+        model = Event
+        fields = ['category',]

--- a/src/kawaz/apps/events/tests/test_views.py
+++ b/src/kawaz/apps/events/tests/test_views.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.test import TestCase
 from django.contrib.auth.models import AnonymousUser
 from kawaz.core.personas.tests.factories import PersonaFactory
-from .factories import EventFactory
+from .factories import EventFactory, CategoryFactory
 from ..models import Event
 from .utils import static_now
 from .utils import event_factory_with_relative
@@ -294,6 +294,20 @@ class EventListViewTestCase(TestCase):
         self.assertEqual(list.count(), 2, 'object_list has two events')
         self.assertEqual(list[0], self.events[3], '2000/9/5 ~ 6 protected')
         self.assertEqual(list[1], self.events[1], '2000/9/5 ~ 6 public')
+
+    def test_list_with_categories(self):
+        """
+        イベントリストでCategoryのfilterが有効になっている
+        """
+        category = CategoryFactory()
+        event1 = EventFactory(category=category)
+        event2 = EventFactory()
+        self.assertTrue(self.client.login(username=self.user,
+                                          password='password'))
+        r = self.client.get('/events/?category={}'.format(category.pk))
+        self.assertTemplateUsed(r, 'events/event_list.html')
+        self.assertEqual(len(r.context['filter']), 1)
+        self.assertTrue(event1 in r.context['filter'])
 
 
 @mock.patch('django.utils.timezone.now', static_now)

--- a/src/kawaz/apps/events/views.py
+++ b/src/kawaz/apps/events/views.py
@@ -5,6 +5,8 @@ from django.views.generic.dates import YearArchiveView, MonthArchiveView, BaseAr
 from django.core.urlresolvers import reverse_lazy
 from django.core.exceptions import PermissionDenied
 from django.http.response import HttpResponseRedirect, HttpResponseForbidden, HttpResponseNotAllowed
+from django_filters.views import FilterView
+from .filters import EventFilter
 
 from permission.decorators import permission_required
 
@@ -33,8 +35,10 @@ class EventDateArchiveMixin(BaseArchiveIndexView):
         return self.render_to_response(context)
 
 
-class EventListView(ListView, EventActiveQuerySetMixin):
+class EventListView(FilterView, EventActiveQuerySetMixin):
     model = Event
+    filterset_class = EventFilter
+    template_name_suffix = '_list'
 
 
 @permission_required('events.view_event')


### PR DESCRIPTION
@tunacook event_listで利用できるカテゴリー用のFilterを実装しました。
- 今までobject_listを使ってた所をfilterに変えてください
- `{{ filter.form.category }}`でカテゴリ一覧を取得できます。

たぶんa-sideにこう書けばOK

```
    <div class="panel panel-default">
        <div class="panel-heading">
            <h2 class="panel-title">{% trans "Categories" %}</h2>
        </div>
        {{ filter.form.category }}
    </div>

```

詳しくはproducts/product_list.htmlを参照してください
