### PR TITLE
Eventの月間アーカイブを取得するタグを実装した

### DIFF
--- a/src/kawaz/apps/events/templatetags/events_tags.py
+++ b/src/kawaz/apps/events/templatetags/events_tags.py
@@ -51,3 +51,28 @@ def get_events(context, lookup='published'):
     elif lookup == 'attendable':
         qs = Event.objects.attendable(request.user)
     return qs
+
+
+class Archive:
+    def __init__(self, date, object_list, count):
+        self.date = date
+        self.object_list = object_list
+        self.count = count
+
+
+@register.assignment_tag(takes_context=True)
+def get_monthly_archives(context):
+    """
+    Eventの月間アーカイブを取得する
+
+    Usage:
+        get_monthly_archive as <variable>
+    """
+    qs = Event.objects.all()
+    date_list = qs.datetimes('period_start', 'month', order='DESC')
+
+    archives = []
+    for date in date_list:
+        object_list = qs.filter(**{'period_start__year': date.year}).filter(**{'period_start__month': date.month})
+        archives.append(Archive(date, object_list, object_list.count()))
+    return archives


### PR DESCRIPTION
@tunacook 月別アーカイブを取得するタグを実装しました。

{% load events_tags %}
{% get_monthly_archives as archives %}

```
{% for archive in archives %}
  {% archive.date | date:"Y年M月" %}({{ archive.count }})
{% endfor %}
```

みたいに書いてあげると良い気がします。
