### PR TITLE
get_monthly_archives タグに url 機能を追加した

### DIFF
--- a/src/kawaz/apps/events/tests/test_templatetags.py
+++ b/src/kawaz/apps/events/tests/test_templatetags.py
@@ -165,9 +165,11 @@ class EventGetMonthlyArchiveTemplateTagTestCase(TestCase):
         self.assertEqual(archives[0].count, 1)
         self.assertEqual(archives[0].date.month, 6)
         self.assertEqual(len(archives[0].object_list), 1)
+        self.assertEqual(archives[0].url, '/events/archive/2014/6/')
         self.assertEqual(archives[1].count, 2)
         self.assertEqual(archives[1].date.month, 4)
         self.assertEqual(len(archives[1].object_list), 2)
+        self.assertEqual(archives[1].url, '/events/archive/2014/4/')
 
 
 


### PR DESCRIPTION
get_monthly_archives にて返される Archive に url
アトリビュートを追加したので下記のような処理が可能になった。

```
{% for archive in archives %}
    <a class="{% if archive.url = request.path %} active{% endif %}"
       href="{{ archive.url }}">
    {{ archive.date | date:"Y年m月" }}（{{ archive.count }}）
    </a>
{% endfor %}
```
