### PR TITLE
Mention が指すURLの修正

### DIFF
--- a/src/kawaz/templates/templatetags/mention.html
+++ b/src/kawaz/templates/templatetags/mention.html
@@ -1,1 +1,1 @@
-<a href="{{ user.get_absolute_url }}"><img src="{{ user.get_small_avatar }}">@{{ user.username }}</a>
+<a href="{{ user.profile.get_absolute_url }}"><img src="{{ user.get_small_avatar }}">@{{ user.username }}</a>


### PR DESCRIPTION
`@<username>`で展開されるURLが `/members/<username>` ではなくDjangoが用意する
`/users/<username>` を指しており明らかに目的と異なったため修正
とくにDjango 1.7では上記 `/users/<username>` が廃止されているようなのでこの修正は
必須
