### PR TITLE
truncatecharsを使用している箇所をtruncatechars_htmlを使用するよう変更

### DIFF
--- a/src/kawaz/statics/less/markdown_nostyle.less
+++ b/src/kawaz/statics/less/markdown_nostyle.less
@@ -5,9 +5,12 @@
 .markdown-nostyle {
   p, h1, h2, h3, h4, h5, h6, blockquote, code {
     display: inline;
+    color: @text-color;
     font-weight: normal;
     font-size: @font-size-base;
     margin-right: 5px;
+    background: transparent;
+    border: none;
   }
   strong, em {
     font-weight: normal;

--- a/src/kawaz/templates/announcements/components/announcement_truncated.html
+++ b/src/kawaz/templates/announcements/components/announcement_truncated.html
@@ -18,7 +18,6 @@
         <p class="badge">{{ object.category.label }}</p>
     </div>
     <article class="markdown-nostyle">
-        {# TODO: Fix Me: Django1.7に移行ができ次第、truncatechars から truncatechars_html へ移行すべき #}
-        {{ object.body | markdown | truncatechars:500}}
+        {{ object.body | markdown | truncatechars_html:500}}
     </article>
 </div>

--- a/src/kawaz/templates/blogs/components/entry_truncated.html
+++ b/src/kawaz/templates/blogs/components/entry_truncated.html
@@ -18,7 +18,6 @@
         <p class="badge">{{ object.category.label }}</p>
     </div>
     <article class="markdown-nostyle">
-        {# TODO: Fix Me: Django1.7に移行ができ次第、truncatechars から truncatechars_html へ移行すべき #}
-        {{ object.body | markdown | truncatechars:500}}
+        {{ object.body | markdown | truncatechars_html:500}}
     </article>
 </div>


### PR DESCRIPTION
Django 1.7よりtruncatechars_htmlというより安全なfilterが使用可
