### PR TITLE
ページヘッダーでactiveの場合の色調整 closed #286

### DIFF
--- a/src/statics/less/main.less
+++ b/src/statics/less/main.less
@@ -76,6 +76,8 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
   background-color: @navbar-default-bg;
   border-color: rgba(231,231,231,1);
   .navbar-nav > .active {
+    background: @navbar-default-link-active-bg;
+    border-bottom:3px solid #000;
     a {
       color: #eee;
       &:hover {


### PR DESCRIPTION
![23d34574dc412271e819076088705483](https://cloud.githubusercontent.com/assets/1044064/4736575/d03802e0-59ed-11e4-899d-05d414a75fcb.png)
activeなページは若干背景薄く、マウスオーバーでただの白
