### PR TITLE
Improve snapshot to use content_object instead

### DIFF
--- a/src/lib/django-activities/activities/mediator.py
+++ b/src/lib/django-activities/activities/mediator.py
@@ -69,7 +69,9 @@ class ActivityMediator(object):
         activity = self.alter(instance, activity, **kwargs)
         if activity:
             # save current instance as a snapshot
-            activity.snapshot = instance
+            # the target instance might be changed thus use _content_object
+            # instead of 'instance'
+            activity.snapshot = activity._content_object
             activity.save()
 
     def _post_save_receiver(self, sender, instance, created, **kwargs):
@@ -81,7 +83,9 @@ class ActivityMediator(object):
         activity = self.alter(instance, activity, **kwargs)
         if activity:
             # save current instance as a snapshot
-            activity.snapshot = instance
+            # the target instance might be changed thus use _content_object
+            # instead of 'instance'
+            activity.snapshot = activity._content_object
             activity.save()
 
     def _m2m_changed_receiver(self, sender, instance, **kwargs):
@@ -90,7 +94,9 @@ class ActivityMediator(object):
         activity = self.alter(instance, None, **kwargs)
         if activity:
             # save current instance as a snapshot
-            activity.snapshot = instance
+            # the target instance might be changed thus use _content_object
+            # instead of 'instance'
+            activity.snapshot = activity._content_object
             activity.save()
 
     def connect(self, model):

--- a/src/lib/django-activities/activities/models.py
+++ b/src/lib/django-activities/activities/models.py
@@ -53,6 +53,7 @@ class Activity(models.Model):
     content_type = models.ForeignKey(ContentType)
     object_id = models.PositiveIntegerField('Object ID')
     _snapshot = models.BinaryField(default=None, null=True)
+    _content_object = GenericForeignKey()
 
     created_at = models.DateTimeField(auto_now_add=True)
 


### PR DESCRIPTION
alter メソッド内 での content_type, object_id の書き換え時に正しい snapshot を参照するように変更
