### PR TITLE
プロフィールページでの所属プロジェクト一覧で、アイコンとプロジェクト名の間にマージンつけた closes #440

### DIFF
--- a/src/statics/less/profile.less
+++ b/src/statics/less/profile.less
@@ -56,6 +56,7 @@
 
 .belong-project-icon {
   float: left;
+  margin-right: 5px;
 }
 
 .belong-project-title {


### PR DESCRIPTION
# before

![ec8b5a4a27a657857f0baeccfa02214d](https://cloud.githubusercontent.com/assets/1044064/4825205/7224d668-5f62-11e4-9dee-18eb8d155184.png)
# after

![fdeb32d92de8eeb6ad784d80408f8826](https://cloud.githubusercontent.com/assets/1044064/4825192/537d0960-5f62-11e4-83e2-ed0840a80ec3.png)
