### PR TITLE
メンバー一覧が最大24件しか表示されず、最終ログイン日順に並ぶ仕様が削除され、テストも消されていたので復活した

### DIFF
--- a/src/kawaz/core/personas/views/persona.py
+++ b/src/kawaz/core/personas/views/persona.py
@@ -57,6 +57,7 @@ class PersonaListView(FilterView):
             '_profile__skills',
             '_profile__accounts__service',
         )
+        qs = qs.order_by('-last_login')
         return qs.exclude(role='wille')
 
 

--- a/src/templates/personas/persona_list.html
+++ b/src/templates/personas/persona_list.html
@@ -20,7 +20,7 @@
         </div>
     {% endif %}
     <div class="row" id="persona-list">
-        {% for object in filter %}
+        {% for object in object_list %}
             <div class="thumbnail persona-list-item">
                 <a href="{{ object.get_absolute_url }}">
                     <img class="persona-avatar" alt="{{ object.nickname }}" src="{{ object.get_huge_avatar }}">


### PR DESCRIPTION
closes #488

なぜ消したし
