### PR TITLE
get_related_activityの仕様にあわせてテンプレートを変えた ref #514

### DIFF
--- a/src/templates/activities/base.html
+++ b/src/templates/activities/base.html
@@ -19,7 +19,9 @@
 
             <div class="activity-history">
                 {% block history %}
-                    {% for inner_activity in activity.get_related_activities|slice:":3" %}
+                    {# 自分自身と、過去の物2つ、3件を更新履歴として表示する #}
+                    {% render_activity activity %}
+                    {% for inner_activity in activity.get_related_activities|slice:":2" %}
                         {% render_activity inner_activity %}
                     {% endfor %}
                 {% endblock %}


### PR DESCRIPTION
最新の物が表示されていなかったの直した

キャッシュの方は直ってるか不明だから、確認できるまでチケットはそのまま
