### PR TITLE
Personaの通知周りで500が出てた問題を修正。プロフィールの更新通知がおかしかったのも修正

### DIFF
--- a/src/kawaz/core/personas/activities/persona.py
+++ b/src/kawaz/core/personas/activities/persona.py
@@ -12,17 +12,20 @@ class PersonaActivityMediator(ActivityMediator):
     def alter(self, instance, activity, **kwargs):
         if activity and activity.status == 'updated':
             # 通知が必要な状態の変更を詳細に記録する
-            previous = activity.previous.snapshot
+            previous = getattr(activity.previous, 'snapshot', None)
             is_created = lambda x: (
+                previous and
                 not getattr(previous, x, None) and
                 getattr(instance, x)
             )
             is_updated = lambda x: (
+                previous and
                 getattr(previous, x, None) and
                 getattr(instance, x) and
                 getattr(previous, x, None) != getattr(instance, x)
             )
             is_deleted = lambda x: (
+                previous and
                 getattr(previous, x, None) and
                 not getattr(instance, x)
             )

--- a/src/kawaz/core/personas/activities/profile.py
+++ b/src/kawaz/core/personas/activities/profile.py
@@ -15,39 +15,9 @@ class ProfileActivityMediator(ActivityMediator):
             activity.content_type = ct
             activity.object_id = pk
             activity.status = 'profile_updated'
-
-            previous = activity.previous.snapshot
-            is_created = lambda x: (
-                not getattr(previous, x, None) and
-                getattr(instance, x)
-            )
-            is_updated = lambda x: (
-                getattr(previous, x, None) and
-                getattr(instance, x) and
-                getattr(previous, x) != getattr(instance, x)
-            )
-            is_deleted = lambda x: (
-                getattr(previous, x, None) and
-                not getattr(instance, x)
-            )
-            remarks = []
-            attributes = (
-                'remarks',
-                'birthday',
-                'place',
-                'url'
-            )
-            for attribute in attributes:
-                if is_created(attribute):
-                    remarks.append(attribute + '_created')
-                elif is_updated(attribute):
-                    remarks.append(attribute + '_updated')
-                elif is_deleted(attribute):
-                    remarks.append(attribute + '_deleted')
-            if not remarks:
-                # 通知が必要な変更ではないため通知しない
-                return None
-            activity.remarks = "\n".join(remarks)
+            # snapshotはPersonaのものになるため
+            # Profileの情報を取り出せない
+            # そのため、フラグをremarksに設定していない
         return activity
 
 

--- a/src/kawaz/core/personas/tests/test_activity.py
+++ b/src/kawaz/core/personas/tests/test_activity.py
@@ -49,8 +49,6 @@ class PersonaActivityMediatorTestCase(BaseActivityMediatorTestCase):
         mediator = registry.get(activity)
         context = Context()
         context = mediator.prepare_context(activity, context)
-        for name in ('place_created', 'birthday_created', 'url_created', 'remarks_created'):
-            self.assertTrue(name in context, 'context variable {} is not contained'.format(name))
         self._test_render(activities[0])
 
         # contextにprofileを含んでいる

--- a/src/templates/activities/personas/persona_profile_updated.html
+++ b/src/templates/activities/personas/persona_profile_updated.html
@@ -1,13 +1,4 @@
 {% extends "activities/personas/persona_base.html" %}
 {% block history-item %}
-    {% include "components/small_avatar.html" with user=object render_username=False %}
-    {% if birthday_created or birthday_updated %}
-        誕生日が「<strong>{{ profile.birthday|date:'m/d' }}</strong>」に設定されました
-    {% elif place_created or place_updated %}
-        居住地域が「<strong>{{ profile.place }}</strong>」に設定されました
-    {% elif url_created or url_updated %}
-        URLが「<a href="{{ profile.url }}"><strong>{{ profile.url }}</strong></a>」に設定されました
-    {% elif remarks_updated %}
-        自己紹介が更新されました
-    {% endif %}
+    {% include "components/small_avatar.html" with user=object render_username=False %}プロフィールが更新されました
 {% endblock %}


### PR DESCRIPTION
直した

@lambdalisue 現状のProfileActivityMediatorの実装だと、`snapshot`にPersonaが保存されてしまい、Profileの更新について追えない
面倒なのでこの仕様にしますが、ForeignKeyのsnapshotの扱いを今後どうするか考えた方が良さそう
