### PR TITLE
暫定的にdjango-rest-frameworkのバージョンを固定

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -2,7 +2,7 @@ pyyaml
 pytz
 pillow
 markdown2==2.3.0
-djangorestframework
+djangorestframework==2.4.4
 django-permission==0.8.3
 django-filter
 django-roughpages>=0.1.2


### PR DESCRIPTION
後で3.0対応してテスト直すけど、
現段階ではデプロイ時などの影響を考えて暫定的にバージョンを固定した
