### PR TITLE
イベント詳細ページにて、ヘッダ右カラム（イベント参加ボタンなど）の位置を調整 close #780

### DIFF
--- a/src/statics/less/events.less
+++ b/src/statics/less/events.less
@@ -145,7 +145,7 @@
     }
     .page-header-right {
       text-align: center;
-      padding: 0;
+      padding: 0 0 0 10px;
       .event-status-control {
         width: 220px;
         margin: 10px auto 0;

--- a/src/templates/events/event_detail.html
+++ b/src/templates/events/event_detail.html
@@ -40,7 +40,7 @@
         <h2>{{ event.title }}</h2>
     </div>
     <div class="row event-info-header">
-        <div class="col col-lg-9 col-xs-12 page-header-left">
+        <div class="col col-lg-9 col-xs-8 page-header-left">
             <div class="event-info-wrap event-info-wrap-{% if event.is_over_restriction or event.is_over_deadline or user has 'events.quit_event' of event %}high{% elif event.organizer == user %}low{% else %}middle{% endif %}">
                 <div class="event-info">
                     <div class="event-datetime-wrap event-info-detail">
@@ -75,7 +75,7 @@
                 </div>
             </div>
         </div>
-        <div class="col col-lg-3 col-xs-12 page-header-right">
+        <div class="col col-lg-3 col-xs-4 page-header-right">
             <div class="event-status-control">
                 {# event.number_restriction が設定されている場合は「あと何人」参加可能かを計算し変数に代入 #}
                 {% if even.number_restriction %}


### PR DESCRIPTION
## PC

![791be6965523cd26bf9fc8097588e462](https://cloud.githubusercontent.com/assets/1044064/5453654/db5e1696-856c-11e4-92ae-0a9afb7e879b.png)
## SP

![16c450d62c1d099ba0447fa2df133bda](https://cloud.githubusercontent.com/assets/1044064/5453666/f4313040-856c-11e4-9754-da1e3b931bd5.png)

![05973e7742c1f6d12e2c9b1e0b545946](https://cloud.githubusercontent.com/assets/1044064/5453672/0ad2cd72-856d-11e4-8f98-3f5d5a826d84.png)
