### PR TITLE
ブログカテゴリ変更時のテンプレートでstrongタグが閉じられていないのを直した close #811

### DIFF
--- a/src/templates/activities/blogs/entry_updated.html
+++ b/src/templates/activities/blogs/entry_updated.html
@@ -7,7 +7,7 @@
     {% elif title_updated %}
         タイトルを「<strong>{{ activity.previous.snapshot.title }}</strong>」から「<strong>{{ object.title }}</strong>」に変えました
     {% elif category_updated %}
-        カテゴリを「<strong>{{ activity.previous.snapshot.category.label }}/strong>」から「<strong><{{ object.category.label }}</strong>」へ変えました
+        カテゴリを「<strong>{{ activity.previous.snapshot.category.label }}</strong>」から「<strong>{{ object.category.label }}</strong>」へ変えました
     {% elif body_updated %}
         本文を編集しました
     {% elif category_created %}


### PR DESCRIPTION
## after

![04ab21839dd5d4fbedf159a7f45c0e37](https://cloud.githubusercontent.com/assets/1044064/5470460/397c8956-862b-11e4-9e73-b52a2b704bf1.png)
