### PR TITLE
event-detailで、イベント状態の表示左右位置をちょっと調整

### DIFF
--- a/src/statics/less/events.less
+++ b/src/statics/less/events.less
@@ -145,7 +145,7 @@
     }
     .page-header-right {
       text-align: center;
-      padding: 0 0 0 10px;
+      padding: 0 0 0 15px;
       .event-status-control {
         width: 220px;
         margin: 10px auto 0;


### PR DESCRIPTION
## before

![d1250521d45c7072e4729595a026e95c](https://cloud.githubusercontent.com/assets/1044064/5513370/f9fcc8ca-8834-11e4-88e6-561deaedb843.png)
## after

![638bd409ced048fc3215ab1c41383f49](https://cloud.githubusercontent.com/assets/1044064/5513366/e631ea78-8834-11e4-989f-c6bc575036eb.png)

おわかりいただけたであろうか……
