### PR TITLE
Activityの修正

### DIFF
--- a/src/kawaz/apps/blogs/tests/test_activity.py
+++ b/src/kawaz/apps/blogs/tests/test_activity.py
@@ -1,11 +1,5 @@
-# ! -*- coding: utf-8 -*-
-#
-# created by giginet on 2014/10/18
-#
 from kawaz.apps.blogs.tests.factories import EntryFactory
 from kawaz.core.activities.tests.testcases import BaseActivityMediatorTestCase
-
-__author__ = 'giginet'
 
 
 class EntryActivityMediatorTestCase(BaseActivityMediatorTestCase):
@@ -15,7 +9,11 @@ class EntryActivityMediatorTestCase(BaseActivityMediatorTestCase):
         self._test_create()
 
     def test_update(self):
-        self._test_partial_update(context_names=('title_updated', 'body_updated'), title="タイトル変えました", body='本文変えました')
+        self._test_partial_update(
+            context_names=('title_updated', 'body_updated'),
+            title="タイトル変えました",
+            body='本文変えました'
+        )
 
     def test_delete(self):
         self._test_delete()

--- a/src/kawaz/apps/events/activity.py
+++ b/src/kawaz/apps/events/activity.py
@@ -76,8 +76,6 @@ class EventActivityMediator(ActivityMediator):
             activity = Activity(content_type=ct,
                                 object_id=instance.pk,
                                 status=status)
-            # snapshot を保存
-            activity.snapshot = instance
             # 追加・削除されたユーザーのIDを保存
             activity.remarks = " ".join(map(str, kwargs.get('pk_set')))
         return activity

--- a/src/kawaz/apps/events/models.py
+++ b/src/kawaz/apps/events/models.py
@@ -248,9 +248,11 @@ class Event(models.Model):
 from django.db.models.signals import post_save
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
+from kawaz.core.utils.signals import disable_for_loaddata
 
 
 @receiver(post_save, sender=Event)
+@disable_for_loaddata
 def join_organizer(**kwargs):
     """
     作成者を自動的に参加させるシグナルレシーバ

--- a/src/kawaz/apps/events/tests/test_activity.py
+++ b/src/kawaz/apps/events/tests/test_activity.py
@@ -6,7 +6,6 @@ from activities.models import Activity
 from .factories import EventFactory, PersonaFactory, CategoryFactory
 from kawaz.core.activities.tests.testcases import BaseActivityMediatorTestCase
 from ..models import Event
-from ..activity import EventActivityMediator
 
 
 class EventActivityMediatorTestCase(BaseActivityMediatorTestCase):

--- a/src/kawaz/apps/products/tests/test_activity.py
+++ b/src/kawaz/apps/products/tests/test_activity.py
@@ -47,7 +47,8 @@ class ProductActivityMediatorTestCase(BaseActivityMediatorTestCase):
 
         activity = activities[0]
         self.assertEqual(activity.status, 'release_added')
-        self.assertEqual(activity.snapshot, self.object)
+        self.assertEqual(activity.snapshot,
+                         self.object)
         # remarksにリリースのapp_label,model,pkが入る
         remarks = 'products,packagerelease,{}'.format(release.pk)
         self.assertEqual(activity.remarks, remarks)
@@ -71,7 +72,8 @@ class ProductActivityMediatorTestCase(BaseActivityMediatorTestCase):
 
         activity = activities[0]
         self.assertEqual(activity.status, 'release_added')
-        self.assertEqual(activity.snapshot, self.object)
+        self.assertEqual(activity.snapshot,
+                         self.object)
         # remarksにリリースのapp_label,model,pkが入る
         remarks = 'products,urlrelease,{}'.format(release.pk)
         self.assertEqual(activity.remarks, remarks)
@@ -119,7 +121,8 @@ class ProductActivityMediatorTestCase(BaseActivityMediatorTestCase):
 
         activity = activities[0]
         self.assertEqual(activity.status, 'screenshot_added')
-        self.assertEqual(activity.snapshot, self.object)
+        self.assertEqual(activity.snapshot,
+                         self.object)
         # remarksにスクリーンショットのpkが入る
         remarks = str(ss.pk)
         self.assertEqual(activity.remarks, remarks)

--- a/src/kawaz/apps/projects/__init__.py
+++ b/src/kawaz/apps/projects/__init__.py
@@ -1,5 +1,0 @@
-#! -*- coding: utf-8 -*-
-#
-# created by giginet on 2014/4/15
-#
-__author__ = 'giginet'

--- a/src/kawaz/apps/projects/models.py
+++ b/src/kawaz/apps/projects/models.py
@@ -220,9 +220,11 @@ class Project(models.Model):
 
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from kawaz.core.utils.signals import disable_for_loaddata
 
 
 @receiver(post_save, sender=Project)
+@disable_for_loaddata
 def join_administrator(**kwargs):
     """
     プロジェクト作成時に自動的に管理者をプロジェクトに参加させるシグナル処理

--- a/src/kawaz/apps/projects/tests/test_activity.py
+++ b/src/kawaz/apps/projects/tests/test_activity.py
@@ -1,11 +1,5 @@
-# ! -*- coding: utf-8 -*-
-#
-# created by giginet on 2014/10/18
-#
 from .factories import ProjectFactory
 from kawaz.core.activities.tests.testcases import BaseActivityMediatorTestCase
-
-__author__ = 'giginet'
 
 
 class ProjectActivityMediatorTestCase(BaseActivityMediatorTestCase):

--- a/src/kawaz/core/activities/hatenablog/migrations/0002_auto_20150302_2340.py
+++ b/src/kawaz/core/activities/hatenablog/migrations/0002_auto_20150302_2340.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import kawaz.core.files.storages
+import kawaz.core.activities.hatenablog.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hatenablog', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='hatenablogentry',
+            name='thumbnail',
+            field=models.ImageField(upload_to=kawaz.core.activities.hatenablog.models.HatenablogEntry._get_upload_path, storage=kawaz.core.files.storages.OverwriteStorage(), verbose_name='Image', default=''),
+            preserve_default=True,
+        ),
+    ]

--- a/src/kawaz/core/activities/tests/testcases.py
+++ b/src/kawaz/core/activities/tests/testcases.py
@@ -1,7 +1,3 @@
-# ! -*- coding: utf-8 -*-
-#
-# created by giginet on 2014/10/18
-#
 from django.contrib.contenttypes.models import ContentType
 from django.template import Context
 from django.test import TestCase
@@ -9,7 +5,6 @@ from activities.models import Activity
 from activities.registry import registry
 from kawaz.core.comments.tests.factories import CommentFactory
 
-__author__ = 'giginet'
 
 class BaseActivityMediatorTestCase(TestCase):
     factory_class = None
@@ -40,7 +35,10 @@ class BaseActivityMediatorTestCase(TestCase):
         context = Context()
         context = mediator.prepare_context(activity, context)
         for name in context_names:
-            self.assertTrue(name in context, 'context variable {} is not contained'.format(name))
+            self.assertTrue(
+                name in context,
+                'context variable {} is not contained'.format(name)
+            )
 
         self._test_render(activities[0])
 
@@ -48,7 +46,9 @@ class BaseActivityMediatorTestCase(TestCase):
         ct = ContentType.objects.get_for_model(self.object)
         pk = self.object.pk
         self.object.delete()
-        activity = Activity.objects.filter(content_type=ct, object_id=pk).first()
+        activity = Activity.objects.filter(
+            content_type=ct, object_id=pk
+        ).first()
 
         self.assertEqual(activity.status, 'deleted')
 
@@ -63,6 +63,7 @@ class BaseActivityMediatorTestCase(TestCase):
         # コメントをする
         comment = CommentFactory(content_object=self.object)
 
+        mediator = registry.get(self.object)
         activities = Activity.objects.get_for_object(self.object)
         self.assertEqual(nactivities + 1, activities.count())
 
@@ -75,7 +76,8 @@ class BaseActivityMediatorTestCase(TestCase):
         self._test_render(activity)
         mediator = registry.get(activity)
         context = mediator.prepare_context(activity, Context())
-        self.assertTrue('comment' in context, """context doesn't contain 'comment'""")
+        self.assertTrue('comment' in context,
+                        "context doesn't contain 'comment'")
 
 
     def _test_render(self, activity):

--- a/src/kawaz/core/comments/activity.py
+++ b/src/kawaz/core/comments/activity.py
@@ -1,15 +1,19 @@
-# ! -*- coding: utf-8 -*-
-#
-# created by giginet on 2014/10/23
-#
 from django.contrib.contenttypes.models import ContentType
 from kawaz.core.personas.models import Persona
 from activities.models import Activity
 from activities.mediator import ActivityMediator
+from activities.registry import registry
 
-__author__ = 'giginet'
 
 class CommentActivityMediator(ActivityMediator):
+
+    def translate_snapshot(self, snapshot):
+        # 可能な限り対象モデルに合わせたスナップショットを作成する
+        try:
+            mediator = registry.get(snapshot)
+        except KeyError:
+            mediator = super()
+        return mediator.translate_snapshot(snapshot)
 
     def alter(self, instance, activity, **kwargs):
         if activity and activity.status == 'created':

--- a/src/kawaz/core/personas/activities/persona.py
+++ b/src/kawaz/core/personas/activities/persona.py
@@ -1,24 +1,36 @@
-# ! -*- coding: utf-8 -*-
-#
-# created by giginet on 2014/10/15
-#
 from django_comments import Comment
 from activities.mediator import ActivityMediator
+from ..models.persona import Persona
 
-__author__ = 'giginet'
 
-class PersonaActivityMediator(ActivityMediator):
+class PersonaActivityMediatorBase(ActivityMediator):
+    def serialize_snapshot(self, snapshot):
+        serialized_snapshot = super().serialize_snapshot(snapshot)
+        if isinstance(snapshot, Persona):
+            # スナップショット対象がペルソナの場合対応するプロフィール状態
+            # もスナップショットとして保持しておく
+            profile = getattr(snapshot, '_profile', None)
+            profile = super().serialize_snapshot(profile) if profile else None
+            serialized_snapshot['extra_fields'] = {
+                '_profile': profile,
+            }
+        return serialized_snapshot
+
+
+class PersonaActivityMediator(PersonaActivityMediatorBase):
     """
     Note:
         Personaは3つのMediatorからさまざまなイベントが発行される
-        activated: Profileの作成（ユーザーのアクティベート時にプロフィールが作成されるため、
-        プロフィールが生成されたときをアクティベートされたと判定している）
+        activated: Profileの作成（ユーザーのアクティベート時にプロフィールが
+                   作成されるため、プロフィールが生成されたときをアクティベート
+                   されたと判定している）
         profile_updated: プロフィールの更新
         comment_added: コメントの追加
         account_added: アカウントの追加
 
-        updatedイベントは初回更新時の前回との差分がないとき、`last_login`カラムが更新されるだけでも通知されてしまう問題があり
-        対処が面倒なので、ユーザーの更新は一切通知されない仕様にする
+        updatedイベントは初回更新時の前回との差分がないとき、`last_login`カラム
+        が更新されるだけでも通知されてしまう問題があり対処が面倒なので、ユーザ
+        の更新は一切通知されない仕様にする
     """
 
     def alter(self, instance, activity, **kwargs):
@@ -29,7 +41,7 @@ class PersonaActivityMediator(ActivityMediator):
 
     def prepare_context(self, activity, context, typename=None):
         context = super().prepare_context(activity, context, typename)
-        if activity.status == 'updated' or activity.status == 'profile_updated':
+        if activity.status in ('updated', 'profile_updated'):
             # remarks に保存された変更状態を利便のためフラグ化
             # また、プロフィールの更新についてもcontextを発行している
             for flag in activity.remarks.split():

--- a/src/kawaz/core/personas/activities/profile.py
+++ b/src/kawaz/core/personas/activities/profile.py
@@ -1,19 +1,17 @@
 from django.contrib.contenttypes.models import ContentType
 from activities.mediator import ActivityMediator
+from .persona import PersonaActivityMediatorBase
 
-__author__ = 'giginet'
 
-class ProfileActivityMediator(ActivityMediator):
+class ProfileActivityMediator(PersonaActivityMediatorBase):
     def alter(self, instance, activity, **kwargs):
         if activity and activity.status in ('created', 'updated'):
             # あるユーザーのプロフィールが更新、作成されたとき
             # そのActivityをプロフィールについてではなく、
             # そのプロフィールの持ち主のユーザーに所属させる
-            target = instance.user
-            ct = ContentType.objects.get_for_model(type(target))
-            pk = target.pk
+            ct = ContentType.objects.get_for_model(instance.user)
             activity.content_type = ct
-            activity.object_id = pk
+            activity.object_id = instance.user.pk
             if activity.status == 'updated':
                 activity.status = 'profile_updated'
             elif activity.status == 'created':
@@ -27,7 +25,7 @@ class ProfileActivityMediator(ActivityMediator):
         return None
 
 
-class AccountActivityMediator(ActivityMediator):
+class AccountActivityMediator(PersonaActivityMediatorBase):
     def alter(self, instance, activity, **kwargs):
         if activity and activity.status == 'created':
             # プロフィールに新しくサービスアカウントが作成されたとき
@@ -35,10 +33,9 @@ class AccountActivityMediator(ActivityMediator):
             # また、ステータスも`account_added`に変える
             # remarksには付いたアカウントのPKを入れる
             target = instance.profile.user
-            ct = ContentType.objects.get_for_model(type(target))
-            pk = target.pk
+            ct = ContentType.objects.get_for_model(instance.profile.user)
             activity.content_type = ct
-            activity.object_id = pk
+            activity.object_id = instance.profile.user.pk
             activity.status = 'account_added'
             activity.remarks = str(instance.pk)
             return activity

--- a/src/kawaz/core/personas/models/persona.py
+++ b/src/kawaz/core/personas/models/persona.py
@@ -67,7 +67,7 @@ class ActivePersonaManager(PersonaManager):
 
     def get_queryset(self):
         # 常に無効なユーザーは含まない
-        return super().get_query_set().filter(is_active=True)
+        return super().get_queryset().filter(is_active=True)
 
 
 class PersonaBase(ModelBase):

--- a/src/kawaz/core/personas/tests/factories/profile.py
+++ b/src/kawaz/core/personas/tests/factories/profile.py
@@ -8,7 +8,7 @@ from ...models import Profile, Skill, Service, Account
 class ProfileFactory(factory.django.DjangoModelFactory):
     FACTORY_FOR = Profile
 
-    birthday = datetime.datetime(2009, 10, 15, tzinfo=timezone.utc)
+    birthday = datetime.date(2009, 10, 15)
     place = 'グランエターナ'
     url = 'http://www.kawaz.org/'
     user = factory.SubFactory(PersonaFactory)

--- a/src/kawaz/core/personas/tests/test_activity.py
+++ b/src/kawaz/core/personas/tests/test_activity.py
@@ -1,15 +1,10 @@
-# ! -*- coding: utf-8 -*-
-#
-# created by giginet on 2014/10/18
-#
 import datetime
 from django.template import Context
 from activities.models import Activity
 from activities.registry import registry
+from ..models.profile import Profile
 from .factories import PersonaFactory, ProfileFactory, AccountFactory
 from kawaz.core.activities.tests.testcases import BaseActivityMediatorTestCase
-
-__author__ = 'giginet'
 
 
 class PersonaActivityMediatorTestCase(BaseActivityMediatorTestCase):
@@ -54,16 +49,22 @@ class PersonaActivityMediatorTestCase(BaseActivityMediatorTestCase):
         self.assertEqual(Activity.objects.count(), nactivity + 1)
         activity = Activity.objects.first()
         self.assertEqual(activity.status, 'activated')
-        self.assertEqual(activity.snapshot, profile.user)
+        self.assertEqual(activity.snapshot,
+                         profile.user)
 
     def test_update_profile(self):
         """
-        あるユーザーのProfileを更新したとき、profile_updated Activityが発行される
+        ユーザーのProfileを更新したとき、profile_updated Activityが発行される
         """
         profile = ProfileFactory()
 
         # Profileを更新する
-        fields = {'place': 'ネルフ本部', 'birthday': datetime.datetime(2112, 9, 21), 'url': 'http://nerv.com/', 'remarks': 'ねむい'}
+        fields = {
+            'place': 'ネルフ本部',
+            'birthday': datetime.date(2112, 9, 21),
+            'url': 'http://nerv.com/',
+            'remarks': 'ねむい',
+        }
         activities = Activity.objects.get_for_object(profile.user)
         self.assertEqual(len(activities), 1)
         for field, value in fields.items():
@@ -96,7 +97,8 @@ class PersonaActivityMediatorTestCase(BaseActivityMediatorTestCase):
 
     def test_account_added(self):
         """
-        アカウントを作成したとき、ユーザーに対してaccount_added Activityが発行される
+        アカウントを作成したとき、ユーザーに対してaccount_added Activityが
+        発行される
         """
 
         # アカウントを作る

--- a/src/kawaz/core/registrations/models.py
+++ b/src/kawaz/core/registrations/models.py
@@ -28,9 +28,11 @@ add_permission_logic(RegistrationProfile, RegistrationProfilePermissionLogic())
 
 from django.dispatch import receiver
 from registration.signals import user_activated
+from kawaz.core.utils.signals import disable_for_loaddata
 
 
 @receiver(user_activated)
+@disable_for_loaddata
 def setup_for_participation(sender, user, password, is_generated, request, **kwargs):
     user.role = 'children'      # ユーザーをChildrenにする
     user.save()

--- a/src/kawaz/core/utils/signals.py
+++ b/src/kawaz/core/utils/signals.py
@@ -1,0 +1,13 @@
+from functools import wraps
+
+
+def disable_for_loaddata(fn):
+    """
+    A decorator that turn off signal handlers when loading fexture data.
+    """
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        if kwargs.get('raw', False):
+            return
+        fn(*args, **kwargs)
+    return wrapper

--- a/src/lib/django-activities/activities/migrations/0001_initial.py
+++ b/src/lib/django-activities/activities/migrations/0001_initial.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Activity',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True, serialize=False)),
+                ('status', models.CharField(max_length=30)),
+                ('remarks', models.TextField(default='')),
+                ('object_id', models.PositiveIntegerField(verbose_name='Object ID')),
+                ('_snapshot', models.BinaryField(default=None, null=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
+            ],
+            options={
+                'verbose_name': 'Activity',
+                'ordering': ('-created_at',),
+                'verbose_name_plural': 'Activities',
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/src/lib/django-activities/activities/migrations/0002_test.py
+++ b/src/lib/django-activities/activities/migrations/0002_test.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('activities', '0001_initial'),
+    ]
+
+    operations = []
+
+    if getattr(settings, 'TESTING'):
+        # settings.TESTING is assigned in
+        # kawaz.core.tests.runner.KawazDiscoverRunner
+        operations.extend([
+            migrations.CreateModel(
+                name='ActivitiesTestModelA',
+                fields=[
+                    ('id', models.AutoField(
+                        auto_created=True, serialize=False,
+                        primary_key=True, verbose_name='ID')),
+                    ('text', models.CharField(
+                        max_length=255, verbose_name='Text')),
+                ],
+                options={
+                },
+                bases=(models.Model,),
+            ),
+            migrations.CreateModel(
+                name='ActivitiesTestModelB',
+                fields=[
+                    ('id', models.AutoField(
+                        auto_created=True, serialize=False,
+                        primary_key=True, verbose_name='ID')),
+                    ('text', models.CharField(
+                        max_length=255, verbose_name='Text')),
+                ],
+                options={
+                },
+                bases=(models.Model,),
+            ),
+            migrations.CreateModel(
+                name='ActivitiesTestModelC',
+                fields=[
+                    ('id', models.AutoField(
+                        auto_created=True, serialize=False,
+                        primary_key=True, verbose_name='ID')),
+                    ('text', models.CharField(
+                        max_length=255, verbose_name='Text')),
+                ],
+                options={
+                },
+                bases=(models.Model,),
+            ),
+        ])

--- a/src/lib/django-activities/activities/migrations/0003_convert_snapshot_to_dict.py
+++ b/src/lib/django-activities/activities/migrations/0003_convert_snapshot_to_dict.py
@@ -8,18 +8,14 @@ def convert_snapshots(apps, schema_editor):
     Activity = apps.get_model('activities', 'Activity')
     ContentType = apps.get_model('contenttypes', 'ContentType')
     for activity in Activity.objects.all():
-        content_type = ContentType.objects.get(pk=activity.content_type_id)
-        activity._content_object = content_type.get_object_fot_this_type(
-            pk=activity.object_id
-        )
-        mediator = registry.get(activity)
+        ct = ContentType.objects.get(pk=activity.content_type_id)
+        natural_key = "{}.{}".format(ct.app_label, ct.model)
+        mediator = registry._registry[natural_key]
         snapshot = pickle.loads(activity._snapshot)
         if isinstance(snapshot, dict):
-            # Model instalce => dictionary instance convertion was already
-            # applied. Skip.
             continue
-        snapshot_dict = mediator.serialize_snapshot(snapshot)
-        activity._snapshot = pickle.dumps(snapshot_dict)
+        serialized_snapshot = mediator.serialize_snapshot(snapshot)
+        activity._snapshot = pickle.dumps(serialized_snapshot)
         activity.save()
 
 

--- a/src/lib/django-activities/activities/migrations/0003_convert_snapshot_to_dict.py
+++ b/src/lib/django-activities/activities/migrations/0003_convert_snapshot_to_dict.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+import pickle
+from django.db import migrations
+from ..registry import registry
+
+
+def convert_snapshots(apps, schema_editor):
+    Activity = apps.get_model('activities', 'Activity')
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    for activity in Activity.objects.all():
+        content_type = ContentType.objects.get(pk=activity.content_type_id)
+        activity._content_object = content_type.get_object_fot_this_type(
+            pk=activity.object_id
+        )
+        mediator = registry.get(activity)
+        snapshot = pickle.loads(activity._snapshot)
+        if isinstance(snapshot, dict):
+            # Model instalce => dictionary instance convertion was already
+            # applied. Skip.
+            continue
+        snapshot_dict = mediator.serialize_snapshot(snapshot)
+        activity._snapshot = pickle.dumps(snapshot_dict)
+        activity.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '__latest__'),
+        ('activities', '0002_test'),
+    ]
+
+    operations = [
+        migrations.RunPython(convert_snapshots),
+    ]

--- a/src/lib/django-activities/activities/models.py
+++ b/src/lib/django-activities/activities/models.py
@@ -90,12 +90,15 @@ class Activity(models.Model):
         Get a pickled object from database
         """
         if not hasattr(self, SNAPSHOT_CACHE_NAME):
+            snapshot = None
             if self._snapshot:
                 serialized_obj = pickle.loads(self._snapshot)
-                snapshot = self.mediator.deserialize_snapshot(serialized_obj)
-            else:
-                snapshot = None
-
+                if serialized_obj and isinstance(serialized_obj, dict):
+                    snapshot = self.mediator.deserialize_snapshot(
+                        serialized_obj
+                    )
+                else:
+                    snapshot = serialized_obj
             setattr(self, SNAPSHOT_CACHE_NAME, snapshot)
         return getattr(self, SNAPSHOT_CACHE_NAME)
 
@@ -105,7 +108,8 @@ class Activity(models.Model):
         Set object to database as pickled object
         """
         if value:
-            snapshot = pickle.dumps(value)
+            serialized_obj = self.mediator.serialize_snapshot(value)
+            snapshot = pickle.dumps(serialized_obj)
         else:
             snapshot = None
         self._snapshot = snapshot

--- a/src/lib/django-activities/activities/registry.py
+++ b/src/lib/django-activities/activities/registry.py
@@ -1,7 +1,5 @@
 # coding=utf-8
-"""
-"""
-__author__ = 'Alisue <lambdalisue@hashnote.net>'
+from django.db.models import Model
 from django.contrib.contenttypes.models import ContentType
 from .mediator import ActivityMediator
 
@@ -35,12 +33,17 @@ class Registry(object):
         mediator.connect(model)
         self._registry[model] = mediator
 
-    def get(self, activity):
+    def get(self, model_or_activity):
         """
-        Get connected activity mediator of a model which the activity has.
+        Get connected activity mediator of a model which the model connected
+        or the activity has
         """
-        model = activity.content_type.model_class()
-        return self._registry[model]
+        from .models import Activity
+        if isinstance(model_or_activity, Activity):
+            model_or_activity = model_or_activity.content_type.model_class()
+        elif isinstance(model_or_activity, Model):
+            model_or_activity = model_or_activity.__class__
+        return self._registry[model_or_activity]
 
 
 # Create a global instance of registry

--- a/src/lib/django-activities/activities/registry.py
+++ b/src/lib/django-activities/activities/registry.py
@@ -2,6 +2,7 @@
 from django.db.models import Model
 from django.contrib.contenttypes.models import ContentType
 from .mediator import ActivityMediator
+from .models import Activity
 
 
 class Registry(object):
@@ -51,7 +52,6 @@ class Registry(object):
         Get connected activity mediator of a model which the model connected
         or the activity has
         """
-        from .models import Activity
         if isinstance(model_or_activity, Activity):
             model_or_activity = model_or_activity.content_type.model_class()
         elif isinstance(model_or_activity, Model):

--- a/src/lib/django-activities/activities/tests/test_models.py
+++ b/src/lib/django-activities/activities/tests/test_models.py
@@ -8,6 +8,7 @@ from .models import ActivitiesTestModelA as ModelA
 from .models import ActivitiesTestModelB as ModelB
 from .models import ActivitiesTestModelC as ModelC
 from ..models import Activity
+from ..registry import registry
 
 
 class ActivitiesModelsActivityManagerTestCase(TestCase):
@@ -57,6 +58,7 @@ class ActivitiesModelsActivityManagerTestCase(TestCase):
         ex = map(repr, reversed(self.activities[0:3]))
         self.assertQuerysetEqual(qs, ex)
 
+
 class ActivitiesModelsActivityTestCase(TestCase):
     def setUp(self):
         self.models = (
@@ -78,6 +80,9 @@ class ActivitiesModelsActivityTestCase(TestCase):
         self.assertTrue(hasattr(activity, 'snapshot'))
 
     def test_snapshot(self):
+        registry.register(ModelA)
+        registry.register(ModelB)
+        registry.register(ModelC)
         model = self.models[0]
         ct = ContentType.objects.get_for_model(model)
         pk = model.pk

--- a/src/lib/django-activities/activities/tests/test_registry.py
+++ b/src/lib/django-activities/activities/tests/test_registry.py
@@ -3,7 +3,9 @@
 """
 __author__ = 'Alisue <lambdalisue@hashnote.net>'
 from django.test import TestCase
+from django.db.models import Model
 from unittest.mock import MagicMock
+from ..models import Activity
 from ..mediator import ActivityMediator
 from ..registry import Registry
 
@@ -12,31 +14,38 @@ class ActivitiesRegistryTestCase(TestCase):
     def test_register(self):
         registry = Registry()
 
-        model = MagicMock()
+        model = MagicMock(spec=Model)()
+        model._meta.concrete_model._meta.app_label = 'activities'
+        model._meta.concrete_model._meta.model_name = 'mock'
         mediator = MagicMock(spec=ActivityMediator)
 
         registry.register(model, mediator)
         # mediator should be connected to model via 'connect' method
         mediator.connect.assert_called_with(model)
         # model and mediator should be connected in registry as well
-        self.assertEqual(registry._registry[model], mediator)
+        self.assertEqual(registry.get(model), mediator)
 
     def test_register_default(self):
         registry = Registry()
 
-        model = MagicMock()
+        model = MagicMock(spec=Model)()
+        model._meta.concrete_model._meta.app_label = 'activities'
+        model._meta.concrete_model._meta.model_name = 'mock'
 
         registry.register(model)
-        mediator = registry._registry[model]
+        mediator = registry.get(model)
         self.assertEqual(mediator.__class__, ActivityMediator)
 
     def test_get(self):
         registry = Registry()
-        model = MagicMock()
+        model = MagicMock(spec=Model)()
+        model._meta.concrete_model._meta.app_label = 'activities'
+        model._meta.concrete_model._meta.model_name = 'mock'
         mediator = MagicMock(spec=ActivityMediator)
+
         registry.register(model, mediator)
 
-        activity = MagicMock()
-        activity.content_type.model_class = MagicMock(return_value=model)
+        activity = MagicMock(spec=Activity)
+        activity.content_type.model_class.return_value = model
 
         self.assertEqual(registry.get(activity), mediator)


### PR DESCRIPTION
やっと終わった

現在DBに保存されている pickle されたモデルインスタンスを pickle されたシリアライズ辞書に置き換えるPR.
これによって DataMigration にてカラム名の書き換えなどが可能になる（シリアライズされたといってもただの辞書データだから）。適用例はまた今度。

開発版での適用手順は

1. `python manage.py init_database`
2. 上記で勝手に `0003_convert_snapshot_to_dict.py` が適用されてしまうので `python manage.py migrate activities --fake 0002_test` で適用前に戻す
3. `python manage.py loaddata 適当なダンプ.json`
4. `python manage.py migrate activities`

本番での適用手順は

1. 落ち着く
2. メンテナンスモードに移行
3. データベースの最新のバックアップを取る
4. 落ち着く
5. 本番のデータをステージングに全部コピーする
6. ステージング環境にて `python manage.py migrate activities --fake 0002_test` を行う
7. ステージング環境にて `python manage.py migrate` を行う (activities と hatenablog が走るはず）
8. ステージングにて問題がないことを確認
9. 落ち着く
10. ステージングのデータを本番に逆マージ
11. こっそり本番で問題ないことを確認
12. メンテナンス終了

って感じで慎重に。