### PR TITLE
Google API Python ClientがPython3対応してたので差し替え

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -17,7 +17,7 @@ django-appconf
 honcho
 beautifulsoup4
 httplib2
-git+https://github.com/enorvelle/GoogleApiPython3x.git#egg=google_api_python_client
+google-api-python-client
 icalendar
 django_compressor
 livereload


### PR DESCRIPTION
closes #991 

CI通るかテスト