### PR TITLE
ブログ・プロジェクト・作品ページの公開ボタンの文言を修正

### DIFF
--- a/src/locale/ja/LC_MESSAGES/django.po
+++ b/src/locale/ja/LC_MESSAGES/django.po
@@ -711,7 +711,7 @@ msgstr "広報ブログの記事"
 #: src/templates/personas/profile_form.html:27
 #: src/templates/products/product_form.html:68
 msgid "Save"
-msgstr "保存する"
+msgstr "公開する"
 
 #: src/kawaz/core/personas/admin/persona.py:18
 msgid "Personal info"


### PR DESCRIPTION
下書きでもないのに「保存」はおかしい気がしたので「公開」にした