### PR TITLE
Drop Python3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ Temporary Items
 
 # Sphinx
 docs/_build
+
+config/requirements-deploy.txt

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Kawaz
 **All your games are belong to us.**
 
 札幌ゲーム製作者コミュニティ Kawaz_ のポータルサイトの開発ドキュメントです。
-開発・実行は Python_ 3.4 と Django_ 1.8 で行われています。
+開発・実行は Python_ 3.5 と Django_ 1.8.7 で行われています。
 
 .. _Kawaz: http://www.kawaz.org/
 .. _Python: https://www.python.org/

--- a/config/tox.ini
+++ b/config/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist   = {py34,py35}-{django18}
+envlist   = py35-django18
 skipsdist = True
 
 [testenv]
 recreate = True
 changedir = {toxinidir}/../
 basepython=
-    py34: python3.4
     py35: python3.5
 deps=
     django18: django>=1.8,<1.9


### PR DESCRIPTION
本番環境がPython3.5に完全に移行したため、Python3.4のサポートをやめた。

CIの実行時間が半分になりそう