### PR TITLE
ブログ記事を公開した時に「公開」と表示されるようにした closes #987

### DIFF
--- a/src/kawaz/apps/blogs/activity.py
+++ b/src/kawaz/apps/blogs/activity.py
@@ -1,13 +1,8 @@
-# ! -*- coding: utf-8 -*-
-#
-#
-#
-
 from activities.mediator import ActivityMediator
 from django_comments.models import Comment
 
-class EntryActivityMediator(ActivityMediator):
 
+class EntryActivityMediator(ActivityMediator):
     def alter(self, instance, activity, **kwargs):
         # 状態がdraftの場合は通知しない
         if activity and instance.pub_state == 'draft':
@@ -30,14 +25,15 @@ class EntryActivityMediator(ActivityMediator):
                     not getattr(instance, x)
                 )
                 remarks = []
+                if (getattr(previous, 'pub_state') == 'draft' and
+                    getattr(instance, 'pub_state') != 'draft'):
+                    # 前回下書きで今回は下書きじゃない
+                    remarks.append('published')
                 attributes = (
                     'title',
                     'body',
                     'category',
                 )
-                if (getattr(previous, 'pub_state') == 'draft' and
-                            getattr(instance, 'pub_state') == 'public'):
-                    remarks.append('published')
                 for attribute in attributes:
                     if is_created(attribute):
                         remarks.append(attribute + '_created')
@@ -49,6 +45,9 @@ class EntryActivityMediator(ActivityMediator):
                     # 通知が必要な変更ではないため通知しない
                     return None
                 activity.remarks = "\n".join(remarks)
+            else:
+                # 前回存在してなくて、いきなりupdateのとき
+                activity.remarks = 'published'
         return activity
 
 

--- a/src/kawaz/apps/blogs/activity.py
+++ b/src/kawaz/apps/blogs/activity.py
@@ -35,6 +35,9 @@ class EntryActivityMediator(ActivityMediator):
                     'body',
                     'category',
                 )
+                if (getattr(previous, 'pub_state') == 'draft' and
+                            getattr(instance, 'pub_state') == 'public'):
+                    remarks.append('published')
                 for attribute in attributes:
                     if is_created(attribute):
                         remarks.append(attribute + '_created')

--- a/src/kawaz/apps/blogs/tests/test_activity.py
+++ b/src/kawaz/apps/blogs/tests/test_activity.py
@@ -1,3 +1,6 @@
+from django.template import Context
+from activities.registry import registry
+from activities.models import Activity
 from kawaz.apps.blogs.tests.factories import EntryFactory
 from kawaz.core.activities.tests.testcases import BaseActivityMediatorTestCase
 
@@ -20,3 +23,27 @@ class EntryActivityMediatorTestCase(BaseActivityMediatorTestCase):
 
     def test_comment_added(self):
         self._test_comment_added()
+
+    def test_entry_is_published(self):
+        draft_entry = EntryFactory(pub_state='draft')
+
+        # draftなエントリーはActivityが作られない
+        activities = Activity.objects.get_for_object(draft_entry)
+        self.assertEqual(len(activities), 0)
+
+        draft_entry.pub_state = 'public'
+        draft_entry.save()
+
+        activities = Activity.objects.get_for_object(draft_entry)
+        activity = activities[0]
+        self.assertEqual(activity.status, 'updated')
+        mediator = registry.get(activity)
+        context = Context()
+        context = mediator.prepare_context(activity, context)
+        self.assertTrue(
+            'published' in context,
+            'context variable published is not contained'
+        )
+        mediator = registry.get(activity)
+        rendered = mediator.render(activity, Context())
+        self.assertTrue('公開されました' in rendered)

--- a/src/templates/activities/blogs/entry_updated.html
+++ b/src/templates/activities/blogs/entry_updated.html
@@ -1,8 +1,7 @@
 {% extends "activities/blogs/base.html" %}
 {% block history-item %}
     {% include "components/small_avatar.html" with user=object.author render_username=False %}
-    {% if not activity.previous %}
-        {# 下書き状態から公開状態に変えて公開したときにこの表示になるはず #}
+    {% if not activity.previous or published %}
         公開されました
     {% elif title_updated %}
         タイトルを「<strong>{{ activity.previous.snapshot.title }}</strong>」から「<strong>{{ object.title }}</strong>」に変えました


### PR DESCRIPTION
下書きのブログ記事をpublic/internalに変えた時の通知を「公開しました」にした

若干テスト薄い