### PR TITLE
イベント新規作成ページのdatepickerが上手く動かない問題を修正

### DIFF
--- a/src/statics/coffee/form.coffee
+++ b/src/statics/coffee/form.coffee
@@ -80,14 +80,16 @@ $ ->
 
 $ ->
   # datetimepickerを表示させる
-  $("[type='datetime']").datetimepicker({
+  $("[type='datetime']").datetimepicker(
     'format' : 'Y-m-d H:i'
-  })
+    'lang' : 'ja'
+  )
   # datepickerを表示させる
-  $("[type='date']").datetimepicker({
-    'timepicker' : false,
+  $("[type='date']").datetimepicker(
+    'timepicker' : false
     'format' : 'Y-m-d'
-  }).prop('type', 'text')
+    'lang' : 'ja'
+  ).prop('type', 'text')
   # Google Chrome標準のdate pickerがウザいので殺している
   # http://stackoverflow.com/questions/11270675/how-can-i-disable-the-new-chrome-html5-date-input
 


### PR DESCRIPTION
closes #973

アップデートしたら直った。ついでに日本語対応