### PR TITLE
Fix CI failing for KFM parsers

### DIFF
--- a/src/kawaz/apps/kfm/tests/test_parse.py
+++ b/src/kawaz/apps/kfm/tests/test_parse.py
@@ -97,7 +97,7 @@ class ParseKFMTestCase(TestCase):
         original = "```python\nimport os\n```"
         value = parse_kfm(original)
         self.assertEqual(value, (
-            "<div class=\"codehilite\"><pre><code>"
+            "<div class=\"codehilite\"><pre><span></span><code>"
             "<span class=\"kn\">import</span> "
             "<span class=\"nn\">os</span>\n"
             "</code></pre></div>"


### PR DESCRIPTION
Pygments 2.1.1が2/14にリリースされ、HTML formatterの出力結果が若干変わったらしく、テストが落ちてしまっていたので修正しました

https://bitbucket.org/birkenfeld/pygments-main/src/6471f650a17e539e297b50d9d238b7c92f4aba23/CHANGES?fileviewer=file-view-default#CHANGES-54

@lambdalisue レビューお願いします