### PR TITLE
Support django-filter 1.0

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -4,7 +4,7 @@ pillow
 markdown2>=2.3.0
 djangorestframework
 django-permission>=0.8.8
-django-filter>=0.15.3,<1
+django-filter>=1.0.0
 django-roughpages>=0.1.2
 django-thumbnailfield>=0.2.3
 django-inspectional-registration

--- a/src/kawaz/apps/events/tests/test_views.py
+++ b/src/kawaz/apps/events/tests/test_views.py
@@ -316,8 +316,8 @@ class EventListViewTestCase(TestCase):
                                           password='password'))
         r = self.client.get('/events/?category={}'.format(category.pk))
         self.assertTemplateUsed(r, 'events/event_list.html')
-        self.assertEqual(len(r.context['filter']), 1)
-        self.assertTrue(event1 in r.context['filter'])
+        self.assertEqual(len(r.context['filter'].qs), 1)
+        self.assertTrue(event1 in r.context['filter'].qs)
 
 
 @mock.patch('django.utils.timezone.now', static_now)

--- a/src/kawaz/apps/events/tests/test_views.py
+++ b/src/kawaz/apps/events/tests/test_views.py
@@ -316,7 +316,7 @@ class EventListViewTestCase(TestCase):
                                           password='password'))
         r = self.client.get('/events/?category={}'.format(category.pk))
         self.assertTemplateUsed(r, 'events/event_list.html')
-        self.assertEqual(len(r.context['filter'].qs), 1)
+        self.assertEqual(r.context['filter'].qs.count(), 1)
         self.assertTrue(event1 in r.context['filter'].qs)
 
 

--- a/src/kawaz/apps/products/tests/test_views.py
+++ b/src/kawaz/apps/products/tests/test_views.py
@@ -98,7 +98,7 @@ class ProductListViewTestCase(ViewTestCaseBase):
             r = self.client.get('/products/')
             self.assertEqual(r.status_code, 200)
             self.assertTemplateUsed(r, 'products/product_list.html')
-            self.assertIn(product, r.context['filter'])
+            self.assertIn(product, r.context['filter'].qs)
 
     def test_list_with_platforms(self):
         """
@@ -110,9 +110,9 @@ class ProductListViewTestCase(ViewTestCaseBase):
             self.prefer_login(user)
             r = self.client.get('/products/?platforms={}'.format(self.p0.pk))
             self.assertTemplateUsed(r, 'products/product_list.html')
-            self.assertEqual(len(r.context['filter']), 1)
-            self.assertIn(product1, r.context['filter'])
-            self.assertNotIn(product2, r.context['filter'])
+            self.assertEqual(len(r.context['filter'].qs), 1)
+            self.assertIn(product1, r.context['filter'].qs)
+            self.assertNotIn(product2, r.context['filter'].qs)
 
     def test_list_with_categories(self):
         """
@@ -123,9 +123,9 @@ class ProductListViewTestCase(ViewTestCaseBase):
         self.prefer_login(self.members[0])
         r = self.client.get('/products/?categories={}'.format(self.c0.pk))
         self.assertTemplateUsed(r, 'products/product_list.html')
-        self.assertEqual(len(r.context['filter']), 1)
-        self.assertIn(product1, r.context['filter'])
-        self.assertNotIn(product2, r.context['filter'])
+        self.assertEqual(len(r.context['filter'].qs), 1)
+        self.assertIn(product1, r.context['filter'].qs)
+        self.assertNotIn(product2, r.context['filter'].qs)
 
 
 class ProductCreateViewTestCase(ViewTestCaseBase):

--- a/src/kawaz/apps/products/tests/test_views.py
+++ b/src/kawaz/apps/products/tests/test_views.py
@@ -110,7 +110,7 @@ class ProductListViewTestCase(ViewTestCaseBase):
             self.prefer_login(user)
             r = self.client.get('/products/?platforms={}'.format(self.p0.pk))
             self.assertTemplateUsed(r, 'products/product_list.html')
-            self.assertEqual(len(r.context['filter'].qs), 1)
+            self.assertEqual(r.context['filter'].qs.count(), 1)
             self.assertIn(product1, r.context['filter'].qs)
             self.assertNotIn(product2, r.context['filter'].qs)
 
@@ -123,7 +123,7 @@ class ProductListViewTestCase(ViewTestCaseBase):
         self.prefer_login(self.members[0])
         r = self.client.get('/products/?categories={}'.format(self.c0.pk))
         self.assertTemplateUsed(r, 'products/product_list.html')
-        self.assertEqual(len(r.context['filter'].qs), 1)
+        self.assertEqual(r.context['filter'].qs.count(), 1)
         self.assertIn(product1, r.context['filter'].qs)
         self.assertNotIn(product2, r.context['filter'].qs)
 

--- a/src/kawaz/core/personas/filters.py
+++ b/src/kawaz/core/personas/filters.py
@@ -14,3 +14,4 @@ class PersonaFilter(FilterSet):
 
     class Meta:
         model = Persona
+        exclude = ('avatar',)

--- a/src/templates/events/event_list.html
+++ b/src/templates/events/event_list.html
@@ -35,7 +35,7 @@
 
 {% block content-main %}
     <div class="event-list-wrap">
-        {% for event in filter %}
+        {% for event in filter.qs %}
             {% include "events/components/list-item.html" %}
         {% empty %}
             <div class="alert alert-info">

--- a/src/templates/personas/persona_list.html
+++ b/src/templates/personas/persona_list.html
@@ -13,11 +13,11 @@
 {% endblock %}
 {% block content-header %}
     <div class="page-header">
-        <h1>{% trans "Members" %}({{ filter | length }})</h1>
+        <h1>{% trans "Members" %}({{ filter.qs | length }})</h1>
     </div>
 {% endblock %}
 {% block content-main %}
-    {% if filter|length_is:"0" %}
+    {% if filter.qs|length_is:"0" %}
         <div class="alert alert-info">
             <p>該当するメンバーは存在しません</p>
         </div>

--- a/src/templates/personas/persona_list.html
+++ b/src/templates/personas/persona_list.html
@@ -13,11 +13,11 @@
 {% endblock %}
 {% block content-header %}
     <div class="page-header">
-        <h1>{% trans "Members" %}({{ filter.qs | length }})</h1>
+        <h1>{% trans "Members" %}({{ filter.qs.count }})</h1>
     </div>
 {% endblock %}
 {% block content-main %}
-    {% if filter.qs|length_is:"0" %}
+    {% if filter.qs.exists %}
         <div class="alert alert-info">
             <p>該当するメンバーは存在しません</p>
         </div>


### PR DESCRIPTION
- [x] PersonaFilter に `exclude` を明示指定（avatar によるフィルタは不要かつコレが原因でエラーになるので exclude 指定）
- [x] ほか多数変更点があるようなので調査 -> https://django-filter.readthedocs.io/en/latest/guide/migration.html
- [x] [暫定対応](https://github.com/kawazrepos/Kawaz3rd/commit/af908c4b2f46f8359efbcc1aeedc647bc7eab4a3)を外す

https://github.com/kawazrepos/Kawaz3rd/issues/1106