### PR TITLE
翻訳が出なくなっていたのを修正

### DIFF
--- a/src/locale/ja/LC_MESSAGES/django.po
+++ b/src/locale/ja/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-11-21 21:55+0900\n"
-"PO-Revision-Date: 2016-11-23 17:43+0900\n"
+"PO-Revision-Date: 2016-11-23 18:14+0900\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ja\n"
@@ -1154,7 +1154,7 @@ msgstr "下書きの管理"
 
 #: src/templates/base.html:87
 msgid "Edit profile"
-msgstr "プロフィールを\b編集"
+msgstr "プロフィールを編集"
 
 #: src/templates/base.html:88 src/templates/personas/persona_form.html:11
 msgid "Edit user information"

--- a/src/locale/ja/LC_MESSAGES/django.po
+++ b/src/locale/ja/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-11-21 21:55+0900\n"
-"PO-Revision-Date: 2016-11-21 21:56+0900\n"
+"PO-Revision-Date: 2016-11-23 17:43+0900\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ja\n"
@@ -183,10 +183,8 @@ msgid "Attendees"
 msgstr "参加者"
 
 #: src/kawaz/apps/events/forms.py:50
-#, fuzzy
-#| msgid "Attend this event"
 msgid "Add attendees of this event"
-msgstr "このイベントに参加"
+msgstr "このイベントに参加させる"
 
 #: src/kawaz/apps/events/models.py:20 src/kawaz/apps/events/models.py:28
 #: src/kawaz/apps/events/models.py:29 src/kawaz/apps/products/models.py:59
@@ -569,8 +567,6 @@ msgid "The product was successfully deleted."
 msgstr "作品を削除しました"
 
 #: src/kawaz/apps/projects/admin.py:17
-#, fuzzy
-#| msgid "Administrators"
 msgid "Administrator's nickname"
 msgstr "プロジェクトの管理者"
 
@@ -1068,8 +1064,6 @@ msgid "Edit the announcements"
 msgstr "このお知らせを編集"
 
 #: src/templates/announcements/announcement_detail.html:62
-#, fuzzy
-#| msgid "Do you want to delete this comment?"
 msgid "Do you want to delete this announcement?"
 msgstr "この記事を削除してもよろしいですか？"
 
@@ -1100,9 +1094,7 @@ msgid "Create a new announcement"
 msgstr "お知らせを作成する"
 
 #: src/templates/announcements/announcement_list.html:21
-#, fuzzy, python-format
-#| msgid "There is only one announcement entry."
-#| msgid_plural "There are %(counter)s announcement entries."
+#, python-format
 msgid "There is only one announcement announcement."
 msgid_plural "There are %(counter)s announcement entries."
 msgstr[0] "%(counter)s件のお知らせがあります"
@@ -1161,16 +1153,12 @@ msgid "Manage drafts"
 msgstr "下書きの管理"
 
 #: src/templates/base.html:87
-#, fuzzy
-#| msgid "Edit your profile"
 msgid "Edit profile"
-msgstr "プロフィールを編集"
+msgstr "プロフィールを\b編集"
 
 #: src/templates/base.html:88 src/templates/personas/persona_form.html:11
-#, fuzzy
-#| msgid "Change user information"
 msgid "Edit user information"
-msgstr "ユーザー情報の変更"
+msgstr "ユーザー情報の編集"
 
 #: src/templates/base.html:89
 msgid "Change password"
@@ -1181,23 +1169,14 @@ msgid "Central Dogma"
 msgstr "セントラルドグマ"
 
 #: src/templates/base.html:95
-#, fuzzy
-#| msgid "Marduk institute"
 msgid "Marduk Institute"
 msgstr "マルドゥック機関"
 
 #: src/templates/base.html:102
-#, fuzzy
-#| msgid "Demote to 'seele'"
 msgid "Demote to 'Seele'"
 msgstr "「ゼーレ」に降格"
 
 #: src/templates/base.html:109
-#, fuzzy
-#| msgid ""
-#| "!CAUTION! Promoting to 'Adam' is strongly not recommended while you will "
-#| "have any permissions to any objects in this system. It means that you "
-#| "potentially cause critical damages on the system. Are you sure to promote?"
 msgid ""
 "!CAUTION! Promoting to 'Adam' is strongly not recommended, for you will have "
 "ANY permissions to ANY objects in this system, which means you potentially "
@@ -1228,8 +1207,6 @@ msgid "'s blog entries"
 msgstr "のブログ記事"
 
 #: src/templates/blogs/entry_detail.html:64
-#, fuzzy
-#| msgid "Edit the blog entry"
 msgid "Edit this blog entry"
 msgstr "記事を編集"
 
@@ -1238,8 +1215,6 @@ msgid "Do you want to delete this entry?"
 msgstr "この記事を削除してもよろしいですか？"
 
 #: src/templates/blogs/entry_detail.html:68
-#, fuzzy
-#| msgid "Delete the blog entry"
 msgid "Delete this blog entry"
 msgstr "記事を削除"
 
@@ -1266,8 +1241,6 @@ msgid_plural "There are %(counter)s blog entries."
 msgstr[0] "%(counter)s件のブログ記事"
 
 #: src/templates/blogs/entry_list.html:36
-#, fuzzy
-#| msgid "There are no blog entries."
 msgid "There are no drafts of blog entries."
 msgstr "ブログの下書きはありません"
 
@@ -1284,10 +1257,6 @@ msgid "Post a comment"
 msgstr "コメントする"
 
 #: src/templates/comments/components/comment_form.html:19
-#, fuzzy
-#| msgid ""
-#| "Participants are only allowed to comment on the entry. Please login to "
-#| "comment."
 msgid ""
 "Only registered users are allowed to comment on the entry. Please log in to "
 "comment."
@@ -1300,8 +1269,6 @@ msgid "Do you want to delete this comment?"
 msgstr "この記事を削除してもよろしいですか？"
 
 #: src/templates/comments/components/comment_items.html:42
-#, fuzzy
-#| msgid "This comment have been deleted."
 msgid "This comment has been deleted."
 msgstr "このコメントは削除されています"
 
@@ -1584,14 +1551,10 @@ msgid "Application Closed"
 msgstr "参加者締め切りました"
 
 #: src/templates/events/event_detail.html:119
-#, fuzzy
-#| msgid "Application is open"
 msgid "Application Open"
 msgstr "参加者募集中"
 
 #: src/templates/events/event_detail.html:135
-#, fuzzy
-#| msgid "Cancel participation"
 msgid "Cancel Participation"
 msgstr "イベントから抜ける"
 
@@ -1600,8 +1563,6 @@ msgid "Log in to Join"
 msgstr "ログインして参加"
 
 #: src/templates/events/event_detail.html:153
-#, fuzzy
-#| msgid "Participation deadline"
 msgid "Application deadline"
 msgstr "参加締切日"
 
@@ -1611,7 +1572,7 @@ msgstr "まで"
 
 #: src/templates/events/event_detail.html:159
 msgid "No deadline for application"
-msgstr ""
+msgstr "参加締切日なし"
 
 #: src/templates/events/event_detail.html:203
 #, python-format
@@ -1620,8 +1581,6 @@ msgid_plural "There are %(counter)s attendees."
 msgstr[0] "%(counter)s人の参加者が居ます"
 
 #: src/templates/events/event_detail.html:232
-#, fuzzy
-#| msgid "Update the event"
 msgid "Edit the event"
 msgstr "イベントを編集"
 
@@ -1658,10 +1617,7 @@ msgstr "%(nickname)sのプロフィール"
 #: src/templates/personas/persona_detail.html:10
 #: src/templates/personas/persona_detail.html:25
 #: src/templates/personas/persona_detail.html:92
-#, fuzzy, python-format
-#| msgid ""
-#| "%(nickname)s may conceal own profile from non participants. Please login "
-#| "to see the profile."
+#, python-format
 msgid ""
 "%(nickname)s is keeping the profile secret from non participants. Please "
 "login to see the profile."
@@ -1704,17 +1660,13 @@ msgid "Joined Projects"
 msgstr "参加しているプロジェクト"
 
 #: src/templates/personas/persona_detail.html:203
-#, fuzzy
-#| msgid "There are no joinned projects."
 msgid "There are no joined projects."
 msgstr "参加しているプロジェクトはありません"
 
 #: src/templates/personas/persona_form.html:6
 #: src/templates/personas/persona_form.html:15
-#, fuzzy
-#| msgid "Change your user information"
 msgid "Edit your user information"
-msgstr "ユーザー情報の変更"
+msgstr "ユーザー情報の編集"
 
 #: src/templates/personas/persona_list.html:67
 msgid "List of Accounts"
@@ -1750,8 +1702,6 @@ msgid "More Details"
 msgstr "詳細ページ"
 
 #: src/templates/products/product_detail.html:65
-#, fuzzy
-#| msgid "Play Now"
 msgid "Play Now!"
 msgstr "今すぐ遊ぶ！"
 
@@ -1770,20 +1720,14 @@ msgid "Create a new product"
 msgstr "新規作品を公開する"
 
 #: src/templates/products/product_detail.html:120
-#, fuzzy
-#| msgid "Update the product"
 msgid "Edit this product"
 msgstr "作品を編集"
 
 #: src/templates/products/product_detail.html:125
-#, fuzzy
-#| msgid "Do you want to delete the product?"
 msgid "Do you want to delete this product?"
 msgstr "この作品を削除してもよろしいですか？"
 
 #: src/templates/products/product_detail.html:126
-#, fuzzy
-#| msgid "Delete the product"
 msgid "Delete this product"
 msgstr "作品を削除"
 
@@ -1840,14 +1784,6 @@ msgid "Last modified at"
 msgstr "最終更新日"
 
 #: src/templates/projects/project_detail.html:91
-#, fuzzy
-#| msgid ""
-#| "\n"
-#| "                  <p>The status of this project is specified as 'done' "
-#| "but no product of this project exists.</p>\n"
-#| "                  <p>Please make a new product of this project to share "
-#| "the product release to external users.</p>\n"
-#| "              "
 msgid ""
 "\n"
 "                  <p>The status of this project is specified as 'complete' "
@@ -1867,14 +1803,10 @@ msgid "Release product now"
 msgstr "いますぐ作品を公開する"
 
 #: src/templates/projects/project_detail.html:97
-#, fuzzy
-#| msgid "Learn about product"
 msgid "Learn more about product"
 msgstr "作品って何？"
 
 #: src/templates/projects/project_detail.html:102
-#, fuzzy
-#| msgid "This project is already available! Let's play it now."
 msgid "This project is already complete and available! Let's play it now."
 msgstr "このプロジェクトは完成しています"
 
@@ -1911,20 +1843,14 @@ msgid "Create a new project"
 msgstr "新しいプロジェクトを作成する"
 
 #: src/templates/projects/project_detail.html:164
-#, fuzzy
-#| msgid "Update the project"
 msgid "Edit this project"
 msgstr "プロジェクトを編集"
 
 #: src/templates/projects/project_detail.html:169
-#, fuzzy
-#| msgid "Do you want to delete the project?"
 msgid "Do you want to delete this project?"
 msgstr "このプロジェクトを削除してよろしいですか？"
 
 #: src/templates/projects/project_detail.html:170
-#, fuzzy
-#| msgid "Delete the project"
 msgid "Delete this project"
 msgstr "プロジェクトを削除"
 
@@ -1996,10 +1922,6 @@ msgid "Your application have been sent"
 msgstr "登録申請が送信されました"
 
 #: src/templates/registration/registration_complete.html:8
-#, fuzzy
-#| msgid ""
-#| "Your application was sent to administrators. We'll send back to you soon. "
-#| "Just a moment."
 msgid ""
 "Your application was sent to administrators. We'll reach back to you soon."
 msgstr "登録申請が送信されました！管理者から返信があるので少しお待ちください。"
@@ -2045,8 +1967,6 @@ msgid "Slack"
 msgstr "Slack"
 
 #: src/templates/roughpages/helps/staff/registration.html:7
-#, fuzzy
-#| msgid "Register"
 msgid "Registration"
 msgstr "Kawazへ登録"
 
@@ -2059,8 +1979,6 @@ msgid "Published articles"
 msgstr "掲載情報"
 
 #: src/templates/roughpages/registration.html:5
-#, fuzzy
-#| msgid "How to participate"
 msgid "How to register"
 msgstr "メンバー登録について"
 


### PR DESCRIPTION
Got rid of those f\*\*\*\*\*\* "fuzz"ies

Story behind this issue: http://stackoverflow.com/questions/1377372/django-fuzzy-string-translation-not-showing-up