### PR TITLE
fix members' page steam url

### DIFF
--- a/src/kawaz/core/personas/fixtures/production.yaml
+++ b/src/kawaz/core/personas/fixtures/production.yaml
@@ -164,7 +164,7 @@
   pk: 15
   fields:
     label: Steam
-    url_pattern: http://steamcommunity.com/personas/{username}/
+    url_pattern: http://steamcommunity.com/id/{username}/
     icon: personas/services/steam.png
 - model: personas.service
   pk: 16


### PR DESCRIPTION
https://kawaz.slack.com/archives/third-impact/p1481946188000038
> このあいだ日記書いたついでにプロフィールに Steamアカウント登録して気付きましたが、 Steamのリンク http://steamcommunity.com/personas/[ID] になっていますが
> 現在は http://steamcommunity.com/id/[ID] のようですね