### PR TITLE
Fix validation error on the comment form

### DIFF
--- a/src/kawaz/core/comments/forms.py
+++ b/src/kawaz/core/comments/forms.py
@@ -2,13 +2,15 @@
 #
 #
 #
+from django import forms
 from django_comments.forms import CommentForm
-from django.utils.translation import ugettext_lazy as _
 from kawaz.core.forms.fields import MarkdownField
 
 
 
 class KawazCommentForm(CommentForm):
+    name = forms.CharField(required=False)
+    email = forms.EmailField(required=False)
     comment = MarkdownField()
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
コメント欄の不可視フォーム`name`, `email`がバリデーションエラーでひっかかってコメントが投稿できなかった

`An invalid form control with name='name' is not focusable.`的なエラーが出ていた。

これらのフォームは基本的にはユーザーが変更不可能なため、`required=False`にした